### PR TITLE
Add since

### DIFF
--- a/build-dev.command
+++ b/build-dev.command
@@ -318,6 +318,7 @@ function install_terminal_utilities()
   install_rainbow
   brew tap tldr-pages/tldr    # install tl;dr manpages
   homebrew_install tldr
+  cask_install since
 }
 
 # https://github.com/nicoulaj/rainbow

--- a/build-dev.command
+++ b/build-dev.command
@@ -63,6 +63,7 @@ function install_command-line_apps()
     curl
     htop-osx
     iftop
+    spark
     tree
     the_silver_searcher
     unrar


### PR DESCRIPTION
Seen on [One Thing Well](http://onethingwell.org/post/116555707841/since)

> [since](http://welz.org.za/projects/since) is a unix utility similar to tail. Unlike tail, since only shows the lines appended since the last time. It is useful to monitor growing log files.